### PR TITLE
generic scripts for building TPWS files

### DIFF
--- a/make_TPWS.m
+++ b/make_TPWS.m
@@ -1,0 +1,98 @@
+% make_TPWS.m
+
+% Example script for converting a folder of mat files containing detections 
+% into a single TPWS file using make_TPWS_vars.m
+
+% Define input/output locations
+inDir = 'E:\MyFolder'; % identify folder containing detection files.
+myFileFlag = '*.mat'; % include a string to match for identifying the files to be processed.
+iterationNum = 1; % Iteration number, usually 1 when creating TPWS files from scratch.
+saveDir = 'E:\MyTPWSfolder';
+outputFileName = 'SiteA_2012';
+
+% Identify variables containing detection parameters 
+% (See comments in make_TPWS_vars.m for more detail on expected inputs)
+
+myTimeSeries = timeSeriesMat; % Replace "timeSeriesMat" with the name of the 
+% variable containing detection time series in the detection files to be
+% processed. REQUIRED.
+
+myDetectionTimes = detTimesMat; % Replace "detTimesMat" with the name of the 
+% variable containing a vector of detection times in the detection files to be
+% processed. REQUIRED.
+
+mySpectra = spectraMat; % Replace "spectraMat" with the name of the 
+% variable containing detection spectra in the detection files to be
+% processed. Optional, can be []. If NOT provided, 'fftLength' and 'sampleRate'
+% are required.
+
+f = freqVal; % Replace "freqVal" with the name of the variable containing 
+% frequency vector associated with mySpectra. Required if mySpectra is provided.
+
+myPeak2PeakAmp = ppVals; % Replace "ppVals" with the name of the 
+% variable containing peak-to-peak recieved levels in the detection files to be
+% processed. Optional. If not provided, myTfFreq and myTfFunValues is
+% required to estimate this.
+
+myFFTLength = 400; % Replace with your desired FFT or a variable name to 
+% be loaded. Required if spectraMat is NOT provided.
+
+mySampleRate = 200000; % Replace with your sample rate or a variable name
+% be loaded. Required if spectraMat is NOT provided.
+
+myTfFunValues =tfValuesVector; % Replace with the name of the variable 
+% containing your transfer function values. Required if spectra must be
+% calculated peak to recieved levels must be calculated. 
+
+myTfFrequency = tfFreqVector; % Replace with the name of the variable 
+% containing the frequencies associated with your transfer function values.
+% Required if spectra must be calculated peak to recieved levels must be calculated. 
+
+myBandpassEdges = [5,95];% replace with your bandpass filter values or 
+% a variable. Optional, but highly recommended if spectra are being
+% calculated. Removes roll off regions to improve spectral display.
+
+
+%% Begin calculations
+% Find all the files to be processed
+detectionFileList = dir(fullfile(inDir,myFileFlag));
+
+% Initialize variables
+fnew = [];
+MSP = [];
+MSN = [];
+MTT = [];
+MPP = [];
+
+% Iterate over each file, collecting and calculating the various
+% parameters.
+for iFile = 1:length(detectionFileList)
+    % load each detection file
+    thisDetFile = fullfile(detectionFileList(iFile).folder,...
+        detectionFileList(iFile).name);
+    load(thisDetFile)
+    
+    [MPPnew,MTTnew,MSPnew,MSNnew,fnew] = make_TPWS_vars('timeSeries',myTimeSeries,...
+        'detectionTimes',myDetectionTimes,'signalSpectra',mySpectra,'f',f,...
+        'fftLength',myFFTLength,'peak2peakAmp',myPeak2PeakAmp,...
+        'sampleRate',mySampleRate,'tfFunFrequency',myTfFrequency,...
+        'tfFunValues',myTfFunValues,'bandPassEdges',myBandpassEdges);
+    
+    MPP = [MPP;MPPnew];
+    MTT = [MTT;MTTnew];
+    MSN = [MSN;MSNnew];
+    MSP = [MSP;MSPnew];
+    
+    if ~isempty(f)
+        f = fnew;
+    end
+    % Optionally can add logic in here for rolling into a new output file
+    % if things get too large (>1.5 million detections is a rough estimate 
+    % of max desirable file size). Preallocating space for MSP and MSN will
+    % improve performance.
+end
+
+% Save output
+fullOutputFileName = [outputFileName,'_TPWS',num2str(iterationNum),'.mat'];
+save(fullfile(saveDir,fullOutputFileName),'MPP','MSP','MSN','MTT','f','-v7.3')
+

--- a/make_TPWS_vars.m
+++ b/make_TPWS_vars.m
@@ -1,0 +1,202 @@
+function [MPP,MTT,MSP,MSN,f] = make_TPWS_vars(varargin)
+
+% make_TPWS_vars.m
+
+% Simple script takes lists of detection parameters and outputs TPWS
+% variables. See make_TPWS for an example of combining output variables
+% from multiple detection files into one TPWS file
+
+% Inputs
+%   'timeSeries' - REQUIRED. 
+%       A 2D matrix where each row represents the time series of one detection. 
+%       Alignment by maximum amplitude is recommended.
+%
+%   'detectionTimes' - REQUIRED
+%       An Nx1 vector of detection times as Matlab datenums, where N is the
+%       number of detection times.
+%   
+%   'signalSpectra' - Optional, will be calculated from time series if not
+%       provided. 
+%       An [N x nF] matrix where N is the number of detections and nF is
+%       the number of frequency bins in the spectra.
+%       If not provided, 'fftLength' and 'sampleRate' are required.
+% 
+%   'f' - Required if 'signalSpectra' is provided.
+%       If not provided, will be calculated from 'fftLength' and 'sampleRate'.
+%       A [1 x nF] vector of frequencies associated with 'spectra'. 
+%       Units = kHz.
+%
+%   'fftLength' - Required if 'signalSpectra' is NOT provided. 
+%       Number of points to use when calculating the FFT. 
+% 
+%   'sampleRate' - Required if 'signalSpectra' is NOT provided. 
+%       Used to calculate frequency vector associated with spectra.
+%       Units = Hz
+% 
+%   'peak2peakAmp' - Optional, will be calculated from time series if not
+%       provided.
+%       If NOT provided, a transfer function is required. 
+%       Units: dB peak-to-peak, re: 1 \muPa.
+%
+%   'tfFunFrequency' - Required if 'signalSpectra' is NOT provided.
+%                      Required if 'peak2peakAmp' is NOT provided, unless
+%                      size('tfFunVals) = [1,1] (see 'tfFunValues' for details).
+%       Units = kHz
+%       A [1 x nTF] vector of frequencies associated with the transfer
+%       function vector. Will be used to estimate peak to peak amplitude of
+%       detections.
+%
+%   'tfFunValues' - Required if 'peak2peakAmp' is NOT provided.
+%       Units = dB peak-to-peak, re: 1 \muPa.
+%       Used to estimate peak to peak amplitude of detections
+%       Two options are accepted:
+%       a) A single number. In this case, the same adjustment is applied to 
+%       all detections across all frequencies, and regardless of peak frequency.
+%       b) A [1 x nTF] vector of amplitudes associated with the transfer
+%       function frequency vector. Will be used to estimate peak-to-peak 
+%       amplitude of detections, and adjust spectra according to sensor
+%       sensitivity.
+% 
+%   'bandPassEdges' - Optional. Only used if signalSpectra is not provided
+%       A [1x2] vector of upper and lower frequencies used to truncate the 
+%       spectra if the input timeseries have been band passed. Values in
+%       kHz.
+%       
+%       
+%
+% Output:
+% 
+%   MTT - An [N x 1] vector of detection times, where N is the
+%         number of detections.
+%   MPP - An [N x 1] vector of peak to peak received level (RL) amplitudes.
+%   
+%   MSP - An [N x nF] matrix of detection spectra, where nF is the length of
+%        the spectra.
+%   MSN - An [N x maxSampleWindow] matrix of detection timeseries.
+%
+%   f = An Fx1 frequency vector associated with MSPs
+
+timeSeries = [];
+detectionTimes = [];
+signalSpectra = [];
+f = [];
+fftLength = [];
+sampleRate = [];
+peak2peakAmp = [];
+tfFunFrequency = [];
+tfFunValues = [];
+bandPassEdges = [];
+
+tfFunResampled = [];
+
+vIdx = 1;
+while vIdx <= length(varargin)
+    switch varargin{vIdx}
+        case 'timeSeries'
+            timeSeries = varargin{vIdx+1};
+            vIdx = vIdx+2;
+        case 'detectionTimes'
+            detectionTimes = varargin{vIdx+1};
+            vIdx = vIdx+2;
+        case 'signalSpectra'
+            signalSpectra = varargin{vIdx+1};
+            vIdx = vIdx+2;   
+        case 'f'
+            f = varargin{vIdx+1};
+            vIdx = vIdx+2;   
+        case 'fftLength'
+            fftLength = varargin{vIdx+1};
+            vIdx = vIdx+2;   
+        case 'sampleRate'  
+            sampleRate = varargin{vIdx+1};
+            vIdx = vIdx+2;   
+        case 'peak2peakAmp'
+            peak2peakAmp = varargin{vIdx+1};
+            vIdx = vIdx+2;      
+        case 'tfFunFrequency'
+            tfFunFrequency = varargin{vIdx+1};
+            vIdx = vIdx+2;  
+        case 'tfFunValues'
+            tfFunValues = varargin{vIdx+1};
+            vIdx = vIdx+2;  
+        case 'bandPassEdges'
+            bandPassEdges = varargin{vIdx+1};
+            vIdx = vIdx+2; 
+        otherwise
+            sprintf('undefined input value %s',varargin{vIdx})
+            vIdx = vIdx+2; 
+    end
+end
+        
+if isempty(timeSeries)
+    error('timeSeries input is required')
+elseif isempty(detectionTimes)
+    error('detectionTimes input is required')
+elseif isempty(f) && ~isempty(signalSpectra)
+    error('f input is required because spectra were provided')
+elseif isempty(fftLength) && isempty(signalSpectra)
+    error('fftLength input is required to calculate spectra')
+elseif isempty(sampleRate) && isempty(signalSpectra)
+    error('sampleRate input is required to calculate spectra')
+elseif isempty(tfFunValues) && (isempty(peak2peakAmp) || isempty(signalSpectra))
+    error('tfFunValues input required to compute spectra & peak-to-peak amplitudes')
+elseif isempty(tfFunFrequency) && length(tfFunValues) >1
+    error('tfFunFrequency input required to go with tfFunValues vector')
+end
+% Make MSN
+MSN = timeSeries;
+
+% make MTT 
+MTT = detectionTimes;
+
+% Make MSP
+if ~isempty(signalSpectra)
+    MSP = signalSpectra;
+else
+    
+    % Calculate window
+    fftWindow = hann(fftLength)';
+    
+    % Pad waveforms with zeros to reach desired fft length
+    padZeros = [MSN,zeros(size(MSN,1),fftLength-size(MSN,2))];
+    
+    % Compute power spectral density
+    [MSP,fHz] = pwelch(padZeros',fftWindow,0,fftLength,sampleRate);
+
+    % convert to dBs
+    MSP = 10.*log10(abs(MSP'));
+
+    f = fHz./1000; % Convert to kHz
+    
+    % Resample transfer function so it matches your frequency vector
+    tfFunResampled = interp1(tfFunFrequency, tfFunValues, f, 'linear', 'extrap')';
+    
+    % Add transfer function to spectra
+    MSP = MSP + repmat(tfFunResampled,size(MSP,1),1); 
+    
+    % Truncate spectra if filter edges are provided
+    if ~isempty(bandPassEdges)
+        [~,lowIdx] = min(abs(f-bandPassEdges(1)));
+        [~,hiIdx] = min(abs(f-bandPassEdges(2)));
+        MSP = MSP(:,lowIdx:hiIdx);
+        f = f(lowIdx:hiIdx);
+    end
+end
+    
+% Compute MPP
+if ~isempty(peak2peakAmp)
+    MPP = peak2peakAmp;
+else
+    % Figure out the peak frequency of the spectra
+    [~, peakFrIdx] = max(MSP,[],2);
+    % Identify transfer fun value to add
+    if ~isempty(tfFunResampled)
+        % if we haven't done this above, do it here
+    	tfFunResampled = interp1(tfFunFrequency, tfFunValues, f, 'linear', 'extrap')';
+    end
+    peakFrTfVal = tfFunResampled(peakFrIdx);
+    % Compute amplitude from waveform and add tf.
+    MPP = 20*log10(max(MSN,[],2)+abs(min(MSN,[],2))) + peakFrTfVal';
+    
+end
+


### PR DESCRIPTION
This branch contains 2 generic scripts to demonstrate making TPWS files.

make_TPWS_vars.m accepts a variety of inputs and puts them into MTT/MPP/MSP/MSN matrices.

make_TPWS.m is an example script showing how to run `make_TPWS_vars` over a directory of files, to generate one TPWS file and save it.

NOTE: `make_TPWS` will not run as is. It requires the user to modify the input variable names to match whatever they are using in their detector output files, and to specify read/write directories.
