### PR TITLE
Proposed improvements to mkLTSAsessions

### DIFF
--- a/ioGetPwrPtLTSA.m
+++ b/ioGetPwrPtLTSA.m
@@ -1,8 +1,7 @@
-function [pwr,pt] = ioGetPwrPtLTSA(p,fnames,L,K,rfTime,k)
+function [pwr,pt] = ioGetPwrPtLTSA(p,fnames,L,K,rfTime,k,hdr)
 
 % grab the ltsa pwr matrix to plot
-hdr = ioReadLTSAHeader(fullfile(p.ltsaDir,fnames(K,:)));
-nbin = length(L) * hdr.ltsa.nave(L(1)); % # of time bins to get
+nbin = sum(hdr.ltsa.nave(L)); % # of time bins to get 
 fid = fopen(fullfile(hdr.ltsa.inpath,hdr.ltsa.infile),'r');
 % samples to skip over in ltsa file
 skip = hdr.ltsa.byteloc(L(1));
@@ -11,10 +10,7 @@ fseek(fid,skip,-1);    % skip over header + other data
 if ~isempty(k)
     pwr = fread(fid,[hdr.ltsa.nf,nbin],'int8');   % read data
     fclose(fid);
-    % make time vector
-    t = rfTime{K}(L(1));
-    dt = datenum([0 0 0 0 0 5]);
-    [ pt, pwr ] = padLTSAGaps(hdr, L,pwr);
+    [ pt, pwr] = padLTSAGaps(hdr, L,pwr);
 else
     pwr = fread(fid,[hdr.ltsa.nf,nbin],'int8');   % read data
     fclose(fid);

--- a/mkLTSAsessions.m
+++ b/mkLTSAsessions.m
@@ -28,7 +28,7 @@ p = getParams(userFunc,'analysis','mkLTSA');
 
 %% Define subfolder that fit specified iteration
 if p.iterationNum > 1
-    for id = 2: str2num(p.iterationNum) % iternate id times according to p.iterationNum
+    for id = 2: str2num(p.iterationNum) % iterate id times according to p.iterationNum
         subfolder = ['TPWS',num2str(id)];
         p.tpwsDir = (fullfile(p.tpwsDir,subfolder));
     end
@@ -120,17 +120,17 @@ for iD = 1:length(fileMatchIdx)
     
     % Load up rawfile start times
     doff = datenum([2000 0 0 0 0 0]);   % convert ltsa time to millenium time
-    global sTime eTime rfTime
+    sTime = []; eTime = []; rfTime = []; hdrStore = [];
     
     if isempty(sTime)
         if nltsas > 0
             sTime = zeros(nltsas,1); eTime = zeros(nltsas,1);
             disp('reading ltsa headers, please be patient ...')
             for k = 1:nltsas
-                hdr = ioReadLTSAHeader(fullfile(p.ltsaDir,fnames(k,:)));
-                sTime(k) = hdr.ltsa.start.dnum + doff;  % start time of ltsa files
-                eTime(k) = hdr.ltsa.end.dnum + doff;    % end time of ltsa files
-                rfTime{k} = hdr.ltsa.dnumStart + doff; % all rawfiles times for all ltsas
+                hdrStore{k} = ioReadLTSAHeader(fullfile(p.ltsaDir,fnames(k,:)));
+                sTime(k) = hdrStore{k}.ltsa.start.dnum + doff;  % start time of ltsa files
+                eTime(k) = hdrStore{k}.ltsa.end.dnum + doff;    % end time of ltsa files
+                rfTime{k} = hdrStore{k}.ltsa.dnumStart + doff; % all rawfiles times for all ltsas
             end
             disp('done reading ltsa headers')
         else
@@ -186,7 +186,7 @@ for iD = 1:length(fileMatchIdx)
                 if L ~= 1
                     L = [L(1)-1,L]; % get rawfile from before sb(k)
                 end
-                [pwr{k},pt{k}] = ioGetPwrPtLTSA(p,fnames(K,:),L,K,rfTime,k);
+                [pwr{k},pt{k}] = ioGetPwrPtLTSA(p,fnames(K,:),L,K,rfTime,k,hdrStore{K});
             else
                 rfT = rfTime{K};
                 disp('L is empty')
@@ -219,10 +219,10 @@ for iD = 1:length(fileMatchIdx)
                 if Ls ~= 1
                     Ls = [Ls(1)-1,Ls]; % get rawfile from before sb(k)
                 end
-                [pwrLs,ptLs] = ioGetPwrPtLTSA(p,fnames(Ks,:),Ls,Ks,rfTime,[]);
+                [pwrLs,ptLs] = ioGetPwrPtLTSA(p,fnames(Ks,:),Ls,Ks,rfTime,[],hdrStore{Ks});
             end
             if ~isempty(Le)
-                [pwrLe,ptLe] = ioGetPwrPtLTSA(p,fnames(Ke,:),Le,Ke,rfTime,[]);
+                [pwrLe,ptLe] = ioGetPwrPtLTSA(p,fnames(Ke,:),Le,Ke,rfTime,[],hdrStore{Ke});
             end
             
             if isempty(Ls) || isempty(Le)

--- a/padLTSAGaps.m
+++ b/padLTSAGaps.m
@@ -16,10 +16,12 @@ date_fmt = 'mm/dd/yy HH:MM:SS';
 
 rfStarts = hdr.ltsa.dnumStart(L) + Y2K;
 diffRF_s = round(diff(rfStarts)*mnum2secs);
-nbin = length(L) * hdr.ltsa.nave(L(1));
+nbin = sum(hdr.ltsa.nave(L));
 t1 = rfStarts(1);
 dt_dnum = datenum([ 0 0 0 0 0 hdr.ltsa.tave ]);
-rfdt = (hdr.ltsa.dnumEnd(1) - hdr.ltsa.dnumStart(1))*(24*60*60);
+% Assume max raw file size in set is the standard. Anything less should be padded.
+rfdt = max((hdr.ltsa.dnumEnd - hdr.ltsa.dnumStart)*(24*60*60));
+
 gapsidx = find(diffRF_s~=rfdt);
 rfdt_dnum = datenum([ 0 0 0 0 0 rfdt-5 ]);
 if size(unique(diffRF_s), 2) > 1


### PR DESCRIPTION
For speed: Don't read header for every bout.
For variable raw file lengths: Remove places where we assume that first
raw file is the same length as all other raw files. Should help with
timing errors.
Removed some lines in ioGetPwrPtLTSA that were not used.