### PR TITLE
fix small bug

### DIFF
--- a/mkLTSAsessions.m
+++ b/mkLTSAsessions.m
@@ -165,6 +165,8 @@ for iD = 1:length(fileMatchIdx)
     end
     
     %%% Main Loop
+    pt = [];
+    pwr = [];
     % Loop over the number of bouts (sessions)
     k = 1;
     while (k <= nb)


### PR DESCRIPTION
as far as I can tell, pt and pwr weren't clearing in between files. So if disk01a_LTSA1 had 30 sessions, anything after that with <30 sessions would end up with 30 sessions anyway. This caused issues when opening files in detEdit, because the calculated number of LTSA sessions didn't match what was stored in the LTSA1 files.