### PR TITLE
Fix for mistakes that introduce 0 into zID col 2

### DIFF
--- a/detEdit.m
+++ b/detEdit.m
@@ -176,6 +176,10 @@ if exist('labels','var')
     % whatever was in mySpID before.
     p.mySpID = labels;
 end
+if sum(zID(:,2)==0)>0
+    disp('WARNING: Found zeros in ID labels, removing bad rows.')
+    zID(zID(:,2)==0,:) = [];
+end
 save(fNameList.ID,'zID');
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
This should fix an issue where sometimes the wrong key is hit, and zeros get introduced into zID in the second column, and that breaks the color indexing.
This will only fix it the next time the user starts detEdit.