### PR TITLE
Fix bugs auto labels

### DIFF
--- a/ID_toggle.m
+++ b/ID_toggle.m
@@ -14,6 +14,8 @@ if iColor == 99
     set(dHANDLES.ICIFD201,'Visible',dPARAMS.FD_Toggle)
     set(dHANDLES.RLFD51,'Visible',dPARAMS.FD_Toggle)
     set(dHANDLES.RMSFD53,'Visible',dPARAMS.FD_Toggle)
+    set(dHANDLES.SPEFD50,'Visible',dPARAMS.FD_Toggle)
+    set(dHANDLES.WAVFD52,'Visible',dPARAMS.FD_Toggle)
 
     fprintf('Toggled False %s\n',dPARAMS.FD_Toggle)
 elseif iColor == 0
@@ -28,6 +30,8 @@ elseif iColor == 0
     set(dHANDLES.ICI201,'Visible',dPARAMS.NoLabel_Toggle)
     set(dHANDLES.RL51,'Visible',dPARAMS.NoLabel_Toggle)
     set(dHANDLES.RMS53,'Visible',dPARAMS.NoLabel_Toggle)
+    set(dHANDLES.SPE50,'Visible',dPARAMS.NoLabel_Toggle)
+    set(dHANDLES.WAV52,'Visible',dPARAMS.NoLabel_Toggle)
     
     fprintf('Toggled Unlabeled %s\n',dPARAMS.NoLabel_Toggle)
 else
@@ -44,7 +48,8 @@ else
         set(dHANDLES.ICIID201{iColor},'Visible',dPARAMS.ID_Toggle{iColor})
         set(dHANDLES.RLID51{iColor},'Visible',dPARAMS.ID_Toggle{iColor})
         set(dHANDLES.RMSID53{iColor},'Visible',dPARAMS.ID_Toggle{iColor})
-        %set(dHANDLES.SpecID50{iColor},'Visible',dPARAMS.ID_Toggle{iColor})
+        set(dHANDLES.SPEID50{iColor},'Visible',dPARAMS.ID_Toggle{iColor})
+        set(dHANDLES.WAVID52{iColor},'Visible',dPARAMS.ID_Toggle{iColor})
 
         fprintf('Toggled %s %s\n',get(dHANDLES.h10handles.spLabel{iColor},'String'),...
             dPARAMS.ID_Toggle{iColor})

--- a/boutMotion.m
+++ b/boutMotion.m
@@ -179,8 +179,8 @@ end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % Number detection per spectral bin in LTSA
 % make a spectra in figure 50
-dPARAMS.PT(1) = dPARAMS.sb(dPARAMS.k) ;
-dPARAMS.PT(2) = dPARAMS.eb(dPARAMS.k); % start end times for plots
+dPARAMS.PT(1) = dPARAMS.pt{dPARAMS.k}(1); %dPARAMS.sb(dPARAMS.k) ;
+dPARAMS.PT(2) = dPARAMS.pt{dPARAMS.k}(end); %dPARAMS.eb(dPARAMS.k); % start end times for plots
 dPARAMS.pwr1 = dPARAMS.pwr{1,dPARAMS.k};  % LTSA power vector
 nbinS = length(dPARAMS.pwr1 );
 if (nbinS == 0)

--- a/figure201.m
+++ b/figure201.m
@@ -55,7 +55,7 @@ image(dPARAMS.PT,dPARAMS.f/1000,c,'parent',dHANDLES.LTSAsubs(2))
 set(dHANDLES.LTSAsubs(2),'yDir','normal')
 axis(dHANDLES.LTSAsubs(2),[dPARAMS.PT(1) dPARAMS.PT(end) p.ltsaLims])%v2(4)
 ylabel(dHANDLES.LTSAsubs(2),'Frequency (kHz)')
-datetick(dHANDLES.LTSAsubs(2),'keeplimits')
+datetick(dHANDLES.LTSAsubs(2),'x',15,'keeplimits')
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % Bottom panel, Figure 201: Inter-Detection Interval

--- a/figure50.m
+++ b/figure50.m
@@ -5,30 +5,31 @@ global dPARAMS dHANDLES p
 figure(dHANDLES.spectrafig);clf
 dHANDLES.h50 = gca;
 
-if ~isempty(dPARAMS.trueTimes)
-    % plot average true click spectrum
-    plot(dHANDLES.h50,dPARAMS.ft,dPARAMS.trueSpec,'Linewidth',4)
-end
-
-if dPARAMS.ff2 % average false click spec
-    % plot average false click spectrum
+if p.specploton
     hold(dHANDLES.h50, 'on')
-    plot(dHANDLES.h50,dPARAMS.ft,dPARAMS.SPEC2,'r','Linewidth',4)
-    hold(dHANDLES.h50, 'off')
-end
-if dPARAMS.ff3  % average id click spec
-    hold(dHANDLES.h50, 'on')
-       
-    for iC = 1:length(dPARAMS.specIDs) % set colors
-         dHANDLES.SpecID50{iC} = plot(dHANDLES.h50,dPARAMS.ft,...
-             dPARAMS.specID_norm(iC,:),'Linewidth',4);
-
-        set(dHANDLES.SpecID50{iC},'Color',p.colorTab(dPARAMS.specIDs(iC),:),...
-            'Visible',dPARAMS.ID_Toggle{iC})
+    if ~isempty(dPARAMS.trueTimes)% average true spec in blue
+        dHANDLES.SPE50 = plot(dHANDLES.h50,dPARAMS.ft,dPARAMS.trueSpec,'Linewidth',4,...
+            'Visible',dPARAMS.NoLabel_Toggle);
+    end
+    
+    dHANDLES.SPEFD50 = [];
+    if dPARAMS.ff2 % average false spec in red
+        dHANDLES.SPEFD50 = plot(dHANDLES.h50,dPARAMS.ft,dPARAMS.SPEC2,'r',...
+            'Linewidth',4,'Visible',dPARAMS.FD_Toggle);
+    end
+    
+    dHANDLES.SPEID50 = cell(size(p.colorTab,1),1);
+    if dPARAMS.ff3  % average id click spec
+        for iC = 1:length(dPARAMS.specIDs) % set colors
+            iColor = dPARAMS.specIDs(iC);
+            dHANDLES.SPEID50{iColor} = plot(dHANDLES.h50,dPARAMS.ft,...
+                dPARAMS.specID_norm(iC,:),'Linewidth',4);
+            set(dHANDLES.SPEID50{iColor},'Color',p.colorTab(dPARAMS.specIDs(iC),:),...
+                'Visible',dPARAMS.ID_Toggle{iColor})
+        end
     end
     hold(dHANDLES.h50, 'off')
 end
-
 
 % add figure labels
 xlabel(dHANDLES.h50,'Frequency (kHz)');

--- a/figure52.m
+++ b/figure52.m
@@ -7,27 +7,28 @@ clf;
 dHANDLES.h52 = gca;
 
 if p.specploton
-    if ~isempty(dPARAMS.trueTimes)
-        % average true click waveform
-        plot(dHANDLES.h52, dPARAMS.wtrue);
+    hold(dHANDLES.h52, 'on')
+    if ~isempty(dPARAMS.trueTimes) % average true waveform in blue
+        dHANDLES.WAV52 = plot(dHANDLES.h52, dPARAMS.wtrue,'Visible',dPARAMS.NoLabel_Toggle);
     end
-    if dPARAMS.ff2   % average false click spec
-        % plot average false click waveform
-        hold(dHANDLES.h52, 'on')
-        plot(dHANDLES.h52,dPARAMS.wavFD + 0.5 ,'r');
-        hold(dHANDLES.h52, 'off')
+    
+    dHANDLES.WAVFD52 = [];
+    if dPARAMS.ff2   % average false waveform in red
+        dHANDLES.WAVFD52 = plot(dHANDLES.h52,dPARAMS.wavFD + 0.5 ,'r',...
+            'Visible',dPARAMS.FD_Toggle);
     end
-    if dPARAMS.ff3
-        % plot average ID'd click waveform(s)
-        hold(dHANDLES.h52, 'on')
-        hID2 = plot(dHANDLES.h52,(dPARAMS.wavID' +...,
-            -ones(size(dPARAMS.wavID,1),1)'.*rand(1,min(size(dPARAMS.wavID,1)))));
-        
+    
+    dHANDLES.WAVID52 = cell(size(p.colorTab,1),1);
+    if dPARAMS.ff3 % average waveform ID'd in associated color
         for iC = 1:size(dPARAMS.wavID,1) % set colors
-            set(hID2(iC),'Color',p.colorTab(dPARAMS.specIDs(iC),:))
+            iColor = dPARAMS.specIDs(iC);
+            dHANDLES.WAVID52{iColor} = plot(dHANDLES.h52,(dPARAMS.wavID(iC,:)' +...,
+                -ones(size(dPARAMS.wavID(iC,:),1),1)'.*rand(1,min(size(dPARAMS.wavID(iC,:),1)))));
+            set(dHANDLES.WAVID52{iColor},'Color',p.colorTab(dPARAMS.specIDs(iC),:),...
+                'Visible',dPARAMS.ID_Toggle{iColor})
         end
-        hold(dHANDLES.h52, 'off')
     end
+    hold(dHANDLES.h52, 'off')
 end
 
 xlabel(dHANDLES.h52,sprintf('Samples (%0.1fms @ %0.0fkHz)',...

--- a/keyAction.m
+++ b/keyAction.m
@@ -83,7 +83,7 @@ elseif strcmp(dPARAMS.cc,'t') %assign ALL as true
         [~,iCID] = setdiff(zID(:,1),dPARAMS.t);
         zID = zID(iCID,:);
     end
-
+    
     
 elseif (strcmp(dPARAMS.cc,'x') || strcmp(dPARAMS.cc,'z') ) % test click for random False Detect
     if ~isempty(dPARAMS.XFD)
@@ -223,6 +223,48 @@ elseif strcmp(dPARAMS.cc,'e') % re-code one species ID with another
     % 0, remove those from the ID set.
     accidentalZeros = zID(:,2)==0;
     zID(accidentalZeros,:)=[];
+elseif strcmp(dPARAMS.cc,'o') % put all toggles on
+    % toggle falses
+    FDoff = find(strcmp(dPARAMS.FD_Toggle, 'off'), 1);
+    if ~isempty(FDoff)
+        dPARAMS.FD_Toggle = 'on';
+        set(dHANDLES.RLFD201,'Visible',dPARAMS.FD_Toggle)
+        set(dHANDLES.ICIFD201,'Visible',dPARAMS.FD_Toggle)
+        set(dHANDLES.RLFD51,'Visible',dPARAMS.FD_Toggle)
+        set(dHANDLES.RMSFD53,'Visible',dPARAMS.FD_Toggle)
+        set(dHANDLES.SPEFD50,'Visible',dPARAMS.FD_Toggle)
+        set(dHANDLES.WAVFD52,'Visible',dPARAMS.FD_Toggle)
+        fprintf('Toggled False %s\n',dPARAMS.FD_Toggle)
+    end
+    
+    % toggle unlabeled
+    NoLabloff = find(strcmp(dPARAMS.NoLabel_Toggle, 'off'), 1);
+    if ~isempty(NoLabloff)
+        dPARAMS.NoLabel_Toggle = 'on';
+        set(dHANDLES.RL201,'Visible',dPARAMS.NoLabel_Toggle)
+        set(dHANDLES.ICI201,'Visible',dPARAMS.NoLabel_Toggle)
+        set(dHANDLES.RL51,'Visible',dPARAMS.NoLabel_Toggle)
+        set(dHANDLES.RMS53,'Visible',dPARAMS.NoLabel_Toggle)
+        set(dHANDLES.SPE50,'Visible',dPARAMS.NoLabel_Toggle)
+        set(dHANDLES.WAV52,'Visible',dPARAMS.NoLabel_Toggle)
+        fprintf('Toggled Unlabeled %s\n',dPARAMS.NoLabel_Toggle)
+    end
+    
+    iCoff = find(strcmp(dPARAMS.ID_Toggle, 'off'));
+    if ~isempty(iCoff)
+        for iC = 1:size(iCoff,1)
+            iColor = iCoff(iC);
+            dPARAMS.ID_Toggle{iColor}  = 'on';
+            set(dHANDLES.RLID201{iColor},'Visible',dPARAMS.ID_Toggle{iColor})
+            set(dHANDLES.ICIID201{iColor},'Visible',dPARAMS.ID_Toggle{iColor})
+            set(dHANDLES.RLID51{iColor},'Visible',dPARAMS.ID_Toggle{iColor})
+            set(dHANDLES.RMSID53{iColor},'Visible',dPARAMS.ID_Toggle{iColor})
+            set(dHANDLES.SPEID50{iColor},'Visible',dPARAMS.ID_Toggle{iColor})
+            set(dHANDLES.WAVID52{iColor},'Visible',dPARAMS.ID_Toggle{iColor})
+            fprintf('Toggled %s %s\n',get(dHANDLES.h10handles.spLabel{iColor},'String'),...
+                dPARAMS.ID_Toggle{iColor})
+        end
+    end
 else
     if dPARAMS.k == dPARAMS.nb
         uZFD = [];  ia = []; ic = [];


### PR DESCRIPTION
@kfrasier and @MaceyRafter 
I solved some bugs that existed in this branch.

- LTSA wasn't matching with RL and ICI. This is fixed and also works if you want a minimum length of LTSA to show.

- The legend toggle was giving issues, sometimes not showing some of the labels, waveform showed more labels than there were, etc. So this is fixed. 
- I changed that when putting a toggle off, it will put the spectra and waveform also off, because it was hard sometimes to see the different spectra when there were more than 4-5 types. Also the false and unlabeled can be off too
- I put a new key command: "o" for -on-. This command puts all toggles to on (visible). Sometimes is hard to know which ones are clicked as off, and you don't want to be one by one to put it on again. So pressing "o" will put them all to on, and they will be visible. It works for IDs, false, and unlabeled. 